### PR TITLE
Updated endpoints branch

### DIFF
--- a/src/php/class.sicm-spectrum-api.php
+++ b/src/php/class.sicm-spectrum-api.php
@@ -83,9 +83,12 @@ class Sicm_Spectrum_Api {
         ));
     }
 
-    public function classify_text($text) {
+    public function classify_text($text, $author, $stream, $wordpressId) {
         return $this->call_rpc_method('classification', 'classifyText', array(
-            'text' => $text
+            'text' => $text,
+            'author' => $author,
+            'stream' => $stream,
+            'wordpressId' => $wordpressId
         ));
     }
 

--- a/src/php/class.sicm-spectrum-api.php
+++ b/src/php/class.sicm-spectrum-api.php
@@ -83,11 +83,12 @@ class Sicm_Spectrum_Api {
         ));
     }
 
-    public function classify_text($text, $author, $postId, $wordpressId) {
+    public function classify_text($text, $authorName, $authorEmail, $postId, $wordpressId) {
         return $this->call_rpc_method('classification', 'classifyText', array(
             'text' => $text,
             'meta' => array(
-                'authorName' => $author,
+                'authorName' => $authorName,
+                'authorId' => $authorEmail,
                 'streamId' => $postId,
                 'remoteId' => $wordpressId
             )

--- a/src/php/class.sicm-spectrum-api.php
+++ b/src/php/class.sicm-spectrum-api.php
@@ -83,12 +83,13 @@ class Sicm_Spectrum_Api {
         ));
     }
 
-    public function classify_text($text, $authorName, $authorEmail, $postId, $wordpressId) {
+    public function classify_text($text, $authorName, $authorEmail, $authorIpAddress, $postId, $wordpressId) {
         return $this->call_rpc_method('classification', 'classifyText', array(
             'text' => $text,
             'meta' => array(
                 'authorName' => $authorName,
-                'authorId' => $authorEmail,
+                'authorEmail' => $authorEmail,
+                'authorIpAddress' => $authorIpAddress,
                 'streamId' => $postId,
                 'remoteId' => $wordpressId
             )

--- a/src/php/class.sicm-spectrum-api.php
+++ b/src/php/class.sicm-spectrum-api.php
@@ -83,19 +83,23 @@ class Sicm_Spectrum_Api {
         ));
     }
 
-    public function classify_text($text, $author, $stream, $wordpressId) {
+    public function classify_text($text, $author, $postId, $wordpressId) {
         return $this->call_rpc_method('classification', 'classifyText', array(
             'text' => $text,
-            'author' => $author,
-            'stream' => $stream,
-            'wordpressId' => $wordpressId
+            'meta' => array(
+                'authorName' => $author,
+                'streamId' => $postId,
+                'remoteId' => $wordpressId
+            )
         ));
     }
 
-    public function record_user_classification($content, $should_block) {
+    public function record_user_classification($wordpressId, $userPositive) {
         return $this->call_rpc_method('classification', 'recordUserClassification', array(
-            'content' => $content,
-            'shouldBlock' => $should_block
+            'request' => array(
+                'userPositive' => $userPositive,
+                'remoteId' => $wordpressId
+            )
         ));
     }
 


### PR DESCRIPTION
Currently running on our ec2 wordpress blog.

Admin comments and their adjudications do not get sent to our backend.

Because the comment id is not available before the comment enters the Wordpress system, I moved the rpc call to be made after the comment has been created, and got rid of the `preprocess_comment` hook.